### PR TITLE
Add custom_repo variable and some small changes

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: jjaswanson4
 name: configure_satellite
-version: 2.1.5
+version: 2.1.6
 readme: README.md
 authors:
   - Josh Swanson <jswanson@redhat.com>

--- a/roles/configure_foreman/tasks/auth_sources_ldap.yml
+++ b/roles/configure_foreman/tasks/auth_sources_ldap.yml
@@ -57,5 +57,5 @@
     usergroup: "{{ external_group.usergroup }}"
   loop_control:
     loop_var: external_group
-  loop: "{{ satellite.external_groups }}"
+  loop: "{{ satellite.external_groups | default('[]') }}"
   delegate_to: "{{ groups['satellite'][0] }}"

--- a/roles/configure_katello/tasks/activation-keys.yml
+++ b/roles/configure_katello/tasks/activation-keys.yml
@@ -4,7 +4,7 @@
   file:
     path: "{{ role_path }}/tasks/satellite-configuration/{{ organization.organization_name }}/activation-keys"
     state: directory
-  delegate_to: "{{ delegate_host }}"
+  delegate_to: localhost
 
 - name: push task file to create activation key
   template:
@@ -13,7 +13,7 @@
   loop_control:
     loop_var: activation_key
   loop: "{{ organization.activation_keys }}"
-  delegate_to: "{{ delegate_host }}"
+  delegate_to: localhost
 
 - name: include tasks to create activation keys
   include_tasks: "{{ role_path }}/tasks/satellite-configuration/{{ organization.organization_name }}/activation-keys/{{ activation_key.name }}.yml"

--- a/roles/configure_katello/tasks/associate-redhat-products-with-sync-plan.yml
+++ b/roles/configure_katello/tasks/associate-redhat-products-with-sync-plan.yml
@@ -5,6 +5,8 @@
   register: redhat_products
   changed_when: false
   check_mode: false
+  ignore_errors: true #in case there are no red hat repos for this organization
+
 
 - name: set Red Hat products to sync plan
   theforeman.foreman.product:

--- a/roles/configure_katello/tasks/composite-content-views.yml
+++ b/roles/configure_katello/tasks/composite-content-views.yml
@@ -4,7 +4,7 @@
   file:
     path: "{{ role_path }}/tasks/satellite-configuration/{{ organization.organization_name }}/content-views"
     state: directory
-  delegate_to: "{{ delegate_host }}"
+  delegate_to: localhost
 
 - name: push task file to create composite content view
   template:
@@ -13,7 +13,7 @@
   loop_control:
     loop_var: composite_content_view
   loop: "{{ organization.composite_content_views }}"
-  delegate_to: "{{ delegate_host }}"
+  delegate_to: localhost
 
 - name: include tasks to create composite content views
   include_tasks: "{{ role_path }}/tasks/satellite-configuration/{{ organization.organization_name }}/content-views/{{ composite_content_view.name }}.yml"

--- a/roles/configure_katello/tasks/content-views.yml
+++ b/roles/configure_katello/tasks/content-views.yml
@@ -4,7 +4,7 @@
   file:
     path: "{{ role_path }}/tasks/satellite-configuration/{{ organization.organization_name }}/content-views"
     state: directory
-  delegate_to: "{{ delegate_host }}"
+  delegate_to: localhost
 
 - name: push task file to create content view based on number of repos
   template:
@@ -13,7 +13,7 @@
   loop_control:
     loop_var: content_view
   loop: "{{ organization.content_views }}"
-  delegate_to: "{{ delegate_host }}"
+  delegate_to: localhost
 
 - name: include tasks to create content views
   include_tasks: "{{ role_path }}/tasks/satellite-configuration/{{ organization.organization_name }}/content-views/{{ content_view.name }}.yml"

--- a/roles/configure_katello/tasks/custom-products.yml
+++ b/roles/configure_katello/tasks/custom-products.yml
@@ -8,11 +8,11 @@
     server_url: "{{ satellite_url }}"
     organization: "{{ organization.organization_name }}"
     name: "{{ product.1.product }}"
-    gpg_key: "{{ product.1.content_credential_name }}"
-    sync_plan: daily
+    gpg_key: "{{ product.1.content_credential_name | default(omit) }}"
+    sync_plan: "{{ product.1.sync_plan | default('daily') }}"
   when:
     - product.1.product is defined
-    - product.1.content_credential_name is defined
+    - product.1.custom_repo is defined
   loop_control:
     loop_var: product
   loop: "{{ organization.content_views | subelements('repos') }}"

--- a/roles/configure_katello/tasks/custom-repos.yml
+++ b/roles/configure_katello/tasks/custom-repos.yml
@@ -17,6 +17,8 @@
     gpg_key: "{{ repo.1.content_credential_name }}"
     checksum_type: "{{ repo.1.checksum_type | default(omit) }}"
     unprotected: "{{ repo.1.unprotected | default(omit) }}"
+    upstream_username: "{{ repo.1.upstream_username | default(omit) }}"
+    upstream_password: "{{ repo.1.upstream_password | default(omit) }}"
   when:
     - repo.1.repo is defined
     - repo.1.product is defined

--- a/roles/configure_katello/tasks/custom-repos.yml
+++ b/roles/configure_katello/tasks/custom-repos.yml
@@ -14,7 +14,7 @@
     url: "{{ repo.1.repo_url }}"
     mirror_on_sync: "{{ repo.1.mirror_on_sync | default(false) }}"
     download_policy: "{{ repo.1.download_policy | default('immediate') }}"
-    gpg_key: "{{ repo.1.content_credential_name }}"
+    gpg_key: "{{ repo.1.content_credential_name | default(omit) }}"
     checksum_type: "{{ repo.1.checksum_type | default(omit) }}"
     unprotected: "{{ repo.1.unprotected | default(omit) }}"
     upstream_username: "{{ repo.1.upstream_username | default(omit) }}"
@@ -23,7 +23,7 @@
     - repo.1.repo is defined
     - repo.1.product is defined
     - repo.1.repo_url is defined
-    - repo.1.content_credential is defined
+    - repo.1.custom_repo is defined
   loop_control:
     loop_var: repo
   loop: "{{ organization.content_views | subelements('repos') }}"

--- a/roles/configure_katello/tasks/main.yml
+++ b/roles/configure_katello/tasks/main.yml
@@ -3,7 +3,12 @@
 - import_tasks: manifest.yml
 - import_tasks: lifecycle-environments.yml
 - import_tasks: redhat-repos.yml
-- import_tasks: content-credentials.yml
+- include_tasks: content-credentials.yml
+  when:
+    - content_credential.1.content_credential is defined
+  loop_control:
+    loop_var: content_credential
+  loop: "{{ organization.content_views | subelements('repos') }}"
 - import_tasks: sync-plan.yml
 - import_tasks: custom-products.yml
 - import_tasks: associate-redhat-products-with-sync-plan.yml

--- a/roles/configure_katello/tasks/manifest.yml
+++ b/roles/configure_katello/tasks/manifest.yml
@@ -8,6 +8,8 @@
     group: root
     mode: 0600
   register: stage_manifest
+  when:
+    - organization.manifest is defined
 
 - name: upload manifest
   theforeman.foreman.subscription_manifest:

--- a/roles/configure_katello/tasks/redhat-repos.yml
+++ b/roles/configure_katello/tasks/redhat-repos.yml
@@ -13,7 +13,7 @@
     - releasever: "{{ repo.1.releasever | default(omit) }}"
       basearch: "{{ repo.1.basearch | default(omit) }}"
   when:
-    - repo.1.content_credential is not defined
+    - repo.1.custom_repo is undefined
   loop_control:
     loop_var: repo
   loop: "{{ organization.content_views | subelements('repos') }}"


### PR DESCRIPTION
Various additions.
Biggest change is to use a variable (custom_repo) for custom repositories and don't rely on the content credentials as it's not always required to set a content credential, which makes it an unreliable source if something is a custom repo or not.
Next is to always use the delegate to localhost for tasks which generate other ansible tasks via templates
If you have any questions let me know