### PR TITLE
adjust vars for custom repos to same as foreman version

### DIFF
--- a/roles/configure_satellite_katello/tasks/custom-repos.yml
+++ b/roles/configure_satellite_katello/tasks/custom-repos.yml
@@ -4,17 +4,21 @@
   redhat.satellite.repository:
     username: "{{ satellite.admin_username }}"
     password: "{{ satellite.admin_password }}"
-    validate_certs: false
+    validate_certs: "{{ repo.1.validate_certs | default(false) }}"
     server_url: "{{ satellite_url }}"
     organization: "{{ organization.organization_name }}"
-    state: present
-    content_type: yum
+    state: "{{ repo.1.state | default('present') }}"
+    content_type: "{{ repo.1.content_type | default('yum') }}"
     name: "{{ repo.1.repo }}"
     product: "{{ repo.1.product }}"
     url: "{{ repo.1.repo_url }}"
-    mirror_on_sync: false
-    download_policy: immediate
-    gpg_key: "{{ repo.1.content_credential_name }}"
+    mirror_on_sync: "{{ repo.1.mirror_on_sync | default(false) }}"
+    download_policy: "{{ repo.1.download_policy | default('immediate') }}"
+    gpg_key: "{{ repo.1.content_credential_name | default(omit) }}"
+    checksum_type: "{{ repo.1.checksum_type | default(omit) }}"
+    unprotected: "{{ repo.1.unprotected | default(omit) }}"
+    upstream_username: "{{ repo.1.upstream_username | default(omit) }}"
+    upstream_password: "{{ repo.1.upstream_password | default(omit) }}"
   when:
     - repo.1.repo is defined
     - repo.1.product is defined


### PR DESCRIPTION
The satellite version of role configure_satellite_katello does not support parameters like download_policy. Adjusted parameters content_views[].repos[] of role configure_satellite_katello to the same as configure_katello